### PR TITLE
fix: playlist dropdown close issue

### DIFF
--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -23,9 +23,15 @@ export default function Home() {
 
     // Default search
     const DEFAULT_SEARCH = "top hits";
-    const pathName = `/search?searchtxt=${localStorage.getItem("search") || DEFAULT_SEARCH}`;
-    const currentSearch = new URLSearchParams(window.location.search).get("searchtxt");
-    if (!currentSearch) navigate(pathName);
+    const searchText = localStorage.getItem("search")
+    if(!searchText) {
+      localStorage.setItem("search", DEFAULT_SEARCH)
+    }
+    const pathName = `/search?searchTxt=${localStorage.getItem("search")}`;
+    const currentSearch = new URLSearchParams(window.location.search).get("searchTxt");
+    if (!currentSearch) {
+      navigate(pathName);
+    }
 }, []);
   return (
     <>

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -9,9 +9,9 @@ import {
   MenubarSub,
   MenubarSubTrigger,
   MenubarSubContent,
+  MenubarItem,
 } from "../components/ui/menubar";
 import { Toaster } from "../components/ui/sonner";
-import { toast } from "sonner";
 
 export default function Menu({ song }) {
   const { playlist } = useStore();
@@ -30,16 +30,13 @@ export default function Menu({ song }) {
               <MenubarSubTrigger>Add to Playlist</MenubarSubTrigger>
               <MenubarSubContent className="w-52 mr-2 ">
                 {playlist.map((list) => (
-                  <div
+                  <MenubarItem
                     key={list.id}
                     className="p-2 rounded-lg  w-full hover:bg-secondary"
-                    onClick={() => (
-                      pushInDb(list.id, song.id),
-                      toast("song added in playlist")
-                    )}
+                    onClick={() => pushInDb(list.id, song.id)}
                   >
                     {list.data.name}
-                  </div>
+                  </MenubarItem>
                 ))}
               </MenubarSubContent>
             </MenubarSub>


### PR DESCRIPTION
fixes #39

made changes to handle default search as "Top hits", closure of playlist dropdown is also fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search initializes reliably and persists via local storage, with corrected URL parameter handling for more consistent navigation.
  * “Add to Playlist” no longer triggers an extra toast; adding proceeds quietly.

* **Refactor**
  * Replaced the generic wrapper with a dedicated menu item component for playlist entries, improving click handling consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->