### PR TITLE
fix:Enhance Toaster component with rich colors and custom toast options

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,6 +7,13 @@ import { ThemeProvider } from "./components/ThemeProvider.jsx";
 createRoot(document.getElementById("root")).render(
   <ThemeProvider defaultTheme="dark" storageKey="music-app-theme">
     <App />
-    <Toaster />
+    <Toaster
+      richColors
+      toastOptions={{
+        classNames: {
+          success: "group-[.toaster]:text-white",
+        },
+      }}
+    />
   </ThemeProvider>
 );


### PR DESCRIPTION
Hey @Anmol-TheDev 
I fixed the main toast issue, but I noticed something with the Menu component.

On my local setup, both the main Toaster and the Menu Toaster get triggered right after login, but in the deployed version, only one appears. It seems like we don’t really need two separate Toasters since there’s already one defined globally.

I’ve attached two images for reference:

Image 1: Behavior without the Menu Toaster
<img width="495" height="134" alt="Screenshot from 2025-10-05 20-58-06" src="https://github.com/user-attachments/assets/babe79a4-6b5d-4f4d-9db7-2df6c1345225" />



Image 2: Behavior with the Menu Toaster
<img width="491" height="177" alt="Screenshot from 2025-10-05 20-57-15" src="https://github.com/user-attachments/assets/80400175-74b9-4600-9357-26a7541a72aa" />


Could you please take a look at the Menu component as well? I think consolidating the toast setup might resolve the inconsistency between local and deployed environments.

Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced toast notifications with richer colors and consistent styling.
  * Improved contrast and readability of toasts across the app.

* **Bug Fixes**
  * Corrected success toast text color to display as white, improving visibility across themes and backgrounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->