### PR TITLE
Implement Retry Logic for API Requests

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -10,6 +10,20 @@ const MAX_RETRIES = 3;
 const BASE_DELAY = 1000; // 1 second
 
 const shouldRetry = (error) => {
+  // Guard against missing config or method
+  if (!error.config || !error.config.method) {
+    return false;
+  }
+
+  const method = error.config.method.toLowerCase();
+  const idempotentMethods = ['get', 'head', 'options', 'put', 'delete'];
+  const isIdempotent = idempotentMethods.includes(method);
+  const retryUnsafe = error.config.retryUnsafe === true;
+
+  if (!isIdempotent && !retryUnsafe) {
+    return false;
+  }
+
   // Retry on network errors, 5xx errors, and rate limits (429)
   if (!error.response) return true; // Network error
   const status = error.response.status;


### PR DESCRIPTION
Added the axios-retry library as a new dependency to handle automatic retries for API requests.
Updated src/Api.js to configure axios-retry with the following:
Retries up to 3 times on network errors and 5xx server errors.
Uses exponential backoff delay between retries.
Does not retry on 4xx client errors to avoid unnecessary retries.
Retained existing error handling with toast notifications for user feedback on API errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic retry with exponential backoff for transient network errors and rate limits, reducing random request failures.
  * Retries occur only when safe; non-retryable errors stop immediately.
  * Error notifications are shown only after all retry attempts fail, reducing noisy toasts.
  * Improves reliability when saving, navigating, or refreshing under flaky connections or temporary outages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->