### PR TITLE
Fixed retry logic in Api.js

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -10,6 +10,20 @@ const MAX_RETRIES = 3;
 const BASE_DELAY = 1000; // 1 second
 
 const shouldRetry = (error) => {
+  // Guard against missing config or method
+  if (!error.config || !error.config.method) {
+    return false;
+  }
+
+  const method = error.config.method.toLowerCase();
+  const idempotentMethods = ['get', 'head', 'options', 'put', 'delete'];
+  const isIdempotent = idempotentMethods.includes(method);
+  const retryUnsafe = error.config.retryUnsafe === true;
+
+  if (!isIdempotent && !retryUnsafe) {
+    return false;
+  }
+
   // Retry on network errors, 5xx errors, and rate limits (429)
   if (!error.response) return true; // Network error
   const status = error.response.status;


### PR DESCRIPTION
Added the axios-retry library as a new dependency to handle automatic retries for API requests.
Updated src/Api.js to configure axios-retry with the following:
Retries up to 3 times on network errors and 5xx server errors.
Uses exponential backoff delay between retries.
Does not retry on 4xx client errors to avoid unnecessary retries.
Retained existing error handling with toast notifications for user feedback on API errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Automatic retries with exponential backoff for eligible requests (network hiccups, temporary server errors, rate limits), improving app reliability.
  * User-facing toasts provide clearer feedback during retries and when issues persist.

* Bug Fixes
  * More resilient handling of intermittent failures reduces random request errors and interruptions.
  * Preserves request intent during retries, minimizing the need for manual re-submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->