### PR TITLE
BUG: Re render of search list page infinitely when song is played.

### DIFF
--- a/src/components/search/SearchResult.jsx
+++ b/src/components/search/SearchResult.jsx
@@ -11,7 +11,11 @@ import Albums from "../Album/Albums";
 
 export default function SearchComponent() {
   const { fetchSongs, songs, fetchAlbums, Topresult } = useFetch();
-  const { setMusicId, musicId, isPlaying, setIsPlaying, currentSong } = useStore();
+  const setMusicId = useStore((state) => state.setMusicId);
+  const musicId = useStore((state) => state.musicId);
+  const isPlaying = useStore((state) => state.isPlaying);
+  const setIsPlaying = useStore((state) => state.setIsPlaying);
+  const currentSong = useStore((state) => state.currentSong);
   const url = useLocation();
   const search = url.search.split("=")[1];
 


### PR DESCRIPTION
The useStore reliability on search list page was triggering re rendering again and again.

Before:
<img width="1512" height="564" alt="Screenshot 2025-10-07 at 10 46 57 PM" src="https://github.com/user-attachments/assets/5851ec91-f99b-481c-b2af-5cfb7e82fbdb" />

After:
<img width="1512" height="633" alt="Screenshot 2025-10-07 at 10 56 43 PM" src="https://github.com/user-attachments/assets/09551a1c-57a0-4f06-be69-188d580ce472" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized state handling within search results to improve responsiveness and reduce UI stutter during playback and selection.
  * Enhances reliability of play/pause toggles and current track indicators under rapid interactions.
  * Fewer unnecessary updates should result in smoother scrolling and more consistent feedback.
  * No visual or workflow changes expected for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->