### PR TITLE
Fix Player Controls for Spacebar

### DIFF
--- a/src/lib/useKeyboardShortcuts.js
+++ b/src/lib/useKeyboardShortcuts.js
@@ -3,44 +3,49 @@ import { useEffect } from "react";
 export default function useKeyboardShortcuts(actions) {
   useEffect(() => {
     const handleKeyDown = (event) => {
-      if (!event.ctrlKey) return;
-      switch (event.code) {
-        case "ArrowRight": // Next track
-          event.preventDefault();
-          actions.nextTrack();
-          break;
-        case "ArrowLeft": // Previous track
-          event.preventDefault();
-          actions.prevTrack();
-          break;
-        case "ArrowUp": // Volume up
-          event.preventDefault();
-          actions.increaseVolume();
-          break;
-        case "ArrowDown": // Volume down
-          event.preventDefault();
-          actions.decreaseVolume();
-          break;
-        default:
-          if (event.ctrlKey) {
-            switch (event.code) {
-              case "Space": // Ctrl + Space → Play/Pause
-                event.preventDefault();
-                actions.togglePlayPause();
-                break;
-              case "KeyM": // Ctrl + M → Mute toggle
-                event.preventDefault();
-actions.toggleMute();
-                break;
-              case "KeyH": // Ctrl + H → Shuffle toggle
-                event.preventDefault();
-                actions.toggleShuffle();
-                break;
-              default:
-                break;
-            }
-          }
-          break;
+      const target = event.target;
+      // Ignore shortcuts if the user is typing in an input field.
+      if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable) {
+        return;
+      }
+
+      // Handle Space bar for play/pause (without Ctrl key)
+      if (event.code === "Space") {
+        event.preventDefault(); // This is the key fix to prevent re-clicking focused buttons
+        actions.togglePlayPause();
+        return; // Stop further execution
+      }
+
+      // Handle other shortcuts that require the Ctrl key
+      if (event.ctrlKey) {
+        switch (event.code) {
+          case "ArrowRight": // Next track
+            event.preventDefault();
+            actions.nextTrack();
+            break;
+          case "ArrowLeft": // Previous track
+            event.preventDefault();
+            actions.prevTrack();
+            break;
+          case "ArrowUp": // Volume up
+            event.preventDefault();
+            actions.increaseVolume();
+            break;
+          case "ArrowDown": // Volume down
+            event.preventDefault();
+            actions.decreaseVolume();
+            break;
+          case "KeyM": // Ctrl + M → Mute toggle
+            event.preventDefault();
+            actions.toggleMute();
+            break;
+          case "KeyH": // Ctrl + H → Shuffle toggle
+            event.preventDefault();
+            actions.toggleShuffle();
+            break;
+          default:
+            break;
+        }
       }
     };
 


### PR DESCRIPTION
Issue Summary
Currently, when the user presses the spacebar, it re-triggers the action of the last button that was clicked (e.g., "Shuffle", "Next", "Previous"). This is because the browser's default behavior is to activate a focused element with the spacebar. The intended behavior is for the spacebar to only toggle the play/pause state of the music player.

Expected Behavior: Pressing the spacebar should always pause or resume playback.

Actual Behavior: The spacebar repeats the action of the last focused button.

Solution Implemented
The issue was resolved by updating the global keyboard shortcut handler in src/lib/useKeyboardShortcuts.js. The fix involves three key modifications:

Isolating the Spacebar Event: A specific condition was added to capture the Space key event independently, without requiring a Ctrl key modifier.

Preventing Default Browser Behavior: event.preventDefault() is now called when the spacebar is pressed. This is the most critical part of the fix, as it stops the browser from performing its default action of "clicking" the focused button, ensuring that only our custom play/pause action is executed.

Ignoring Inputs: A check was added to ensure that keyboard shortcuts do not interfere with typing. If the user is focused on an input field, a textarea, or any editable element, the shortcuts are disabled.

Detailed Steps and Code Changes
The entire logic for handling keyboard shortcuts was refined in a single file for a clean, application-wide solution.

File Modified: slash27kushal/music_app/Music_app-main/src/lib/useKeyboardShortcuts.js

Added an Input Field Check: At the beginning of the handleKeyDown function, a condition now checks if the event target is an input, textarea, or content-editable element. If it is, the function returns early, preventing shortcuts from firing while typing.

Created a Dedicated Handler for the Spacebar:

The code now specifically checks if event.code === "Space".

Inside this block, event.preventDefault() is called to stop the default browser action.

The actions.togglePlayPause() function is then called to control the music playback.

Restructured Existing Shortcuts: The remaining shortcuts (like Ctrl + Arrow Keys) were kept inside the if (event.ctrlKey) block to ensure they still work as intended. The original Ctrl + Space binding for play/pause was removed to avoid conflicts.

By implementing these changes, the spacebar now functions as a reliable play/pause button, significantly improving the user experience of the music player.









<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Press Space to play/pause without using modifier keys.
  * Streamlined keyboard shortcuts for playback, volume, mute, and shuffle for more consistent behavior.

* **Bug Fixes**
  * Keyboard shortcuts no longer trigger while typing in inputs, text areas, or editable fields.
  * Prevents unintended page scrolling or focus changes when using Space for play/pause.

* **Improvements**
  * Clear separation between general (Space) and modifier-based shortcuts for more predictable control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->